### PR TITLE
ubuntu, clang, and rust update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH "/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sb
 
 # install rustup
 RUN curl https://sh.rustup.rs -sSf > rustup-install.sh && \
-    sh ./rustup-install.sh -y --default-toolchain 1.26.2-x86_64-unknown-linux-gnu && \
+    sh ./rustup-install.sh -y --default-toolchain 1.37.0-x86_64-unknown-linux-gnu && \
     rm rustup-install.sh
 
 # Install AARCH64 Rust
@@ -19,7 +19,7 @@ RUN /root/.cargo/bin/rustup target add aarch64-unknown-linux-gnu
 RUN /root/.cargo/bin/rustup target add arm-unknown-linux-gnueabihf
 
 # Install rustfmt / cargo fmt for testing
-RUN rustup component add rustfmt-preview
+RUN rustup component add rustfmt
 
 # setup fetching arm packages
 RUN dpkg --add-architecture arm64 && dpkg --add-architecture armhf


### PR DESCRIPTION
Things have been gradually breaking, and now we really just need to move to newer versions of this stuff. We will need to decide what to do with the formatting when we move titanium to this container version.