### PR TITLE
Ubuntu 20.04 and non root rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         cmake \
         cpio \
         dos2unix \
+        execstack \
         gawk \
         gcc-aarch64-linux-gnu \
         gcc-arm-linux-gnueabihf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM starlabio/ubuntu-base:1.6
+FROM starlabio/ubuntu-base:1.7
 MAINTAINER Pete Dietl <pete.dietl@starlab.io>
 
 # setup linkers for Cargo
@@ -88,7 +88,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
 # Install behave and hamcrest for testing
-RUN pip install behave pyhamcrest requests
+RUN pip3 install behave pyhamcrest requests
 
 # We need to install TPM 2.0 tools
 RUN curl -sSfL https://github.com/01org/tpm2-tss/releases/download/1.2.0/tpm2-tss-1.2.0.tar.gz > tpm2-tss-1.2.0.tar.gz && \

--- a/cargo_config
+++ b/cargo_config
@@ -1,0 +1,4 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"


### PR DESCRIPTION
This is primarily to eliminate the need to run the ARM builds as the root user. But also the Ubuntu base image is updated since the previous 19.04 base is EOLed.