### PR TITLE
Point /usr/bin/python at python2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
+RUN update-alternatives --install  /usr/bin/python python /usr/bin/python2.7 1000
+
 # Install behave and hamcrest for testing
 RUN pip3 install behave pyhamcrest requests
 


### PR DESCRIPTION
Ubuntu 20.04 does not have a predefined /usr/bin/python target.